### PR TITLE
Do not use T.strip

### DIFF
--- a/Debian/Control/Text.hs
+++ b/Debian/Control/Text.hs
@@ -29,7 +29,7 @@ module Debian.Control.Text
 import qualified Data.ByteString.Char8 as B
 import Data.Char (toLower, chr)
 import Data.List (find)
-import qualified Data.Text as T (Text, pack, unpack, map, strip, reverse)
+import qualified Data.Text as T (Text, pack, unpack, map, dropAround, reverse)
 import Data.Text.Encoding (decodeUtf8With, encodeUtf8)
 --import Data.Text.IO as T (readFile)
 import qualified Debian.Control.ByteString as B
@@ -92,7 +92,8 @@ instance ControlFunctions T.Text where
         where hasFieldName :: String -> Field' T.Text -> Bool
               hasFieldName name (Field (fieldName',_)) = T.pack name == T.map toLower fieldName'
               hasFieldName _ _ = False
-    stripWS = T.strip
+    stripWS = T.dropAround (`elem` " \t")
+      -- T.strip would also strip newlines
     protectFieldText = protectFieldText'
     asString = T.unpack
 


### PR DESCRIPTION
as it strips newlines, which are significant (otherwise round-tripping a
Comment field starting in the second line is broken). Use T.dropAround
instead.
